### PR TITLE
call /l_unsafe instead of /l

### DIFF
--- a/html/Elements/ShowLock
+++ b/html/Elements/ShowLock
@@ -42,7 +42,7 @@
 %    return unless $u_str;
 %     $TicketLabel = 'This ticket' if $TicketLabel eq 'this ticket';    
 <div class="locked">
-<&|/l, $TicketLabel, $u_str, $ago &>[_1] has been locked by [_2] for [_3]</&>.
+<&|/l_unsafe, $TicketLabel, $u_str, $ago &>[_1] has been locked by [_2] for [_3]</&>.
 </div>
 %}
 <%INIT>


### PR DESCRIPTION
mason is instanced with default_escape_flags=>'h', so the output of $m->scomp('/Elements/ShowUser', User => $u) is escaped by /l component